### PR TITLE
Add a ftplugin for nerdtree, it can resolve the issue 5 very easily

### DIFF
--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -1,0 +1,1 @@
+call signature#BufferRefresh(1)


### PR DESCRIPTION
@kshenoy

Following your idea, I try to find if there are any events for me to hook signature#BufferRefresh(1), it is not easy.

So, I try to read the scripts of nerdtree, I think we can use "filetype" to resolve this issue instead of "buftype" only.

Using fletype=nerdtree to hook signature#BufferRefresh(1) when nerdtree pane buffer created and buftype=nofile to hook  signature#BufferRefresh(1) when we enter nerdtree pane buffer.

Here comes the scripts. It works fine for me, but I have no idea if these changes cause any problems. Need your further verification.

Mark
