### PR TITLE
Adding configuration to control sign highlight group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Oh, and see in all the above strings, I've used double-quotes and not
 single-quotes. That's not cause I love 'em but things go haywire if
 double-quotes aren't used. Also, `\m` and `\p` cannot be set to _Space_  
 
+* `g:SignatureSignTextHL` ( Default : "Exception" )  
+  The highlight group used for mark displays. 
+
 * `g:SignatureMarkerLeader` ( Default: m )  
   Set the key used to toggle markers.  If this key is set to `<leader>m`  
     `<leader>m1` will toggle the marker '!'  

--- a/autoload/signature.vim
+++ b/autoload/signature.vim
@@ -230,6 +230,7 @@ function! s:ToggleSign( mark, mode, lnum ) "          {{{2
   let l:SignatureIncludeMarkers = ( exists('b:SignatureIncludeMarkers') ? b:SignatureIncludeMarkers : g:SignatureIncludeMarkers )
   let l:SignatureLcMarkStr  = ( exists('b:SignatureLcMarkStr')    ? b:SignatureLcMarkStr  : g:SignatureLcMarkStr    )
   let l:SignatureUcMarkStr  = ( exists('b:SignatureUcMarkStr')    ? b:SignatureUcMarkStr  : g:SignatureUcMarkStr    )
+  let l:SignatureSignTextHL  = ( exists('b:SignatureSignTextHL')    ? b:SignatureSignTextHL  : g:SignatureSignTextHL    )
 
   if stridx(l:SignatureIncludeMarkers, a:mark) >= 0
     " Visual marker has been set
@@ -248,7 +249,7 @@ function! s:ToggleSign( mark, mode, lnum ) "          {{{2
           let l:str = substitute(l:SignatureUcMarkStr, "\m", l:mark, "")
         endif
         let l:str = substitute(l:str, "\p", strpart(b:sig_marks[l:lnum], 1, 1), "")
-        execute 'sign define sig_Mark_' . l:id . ' text=' . l:str . ' texthl=Exception'
+        execute 'sign define sig_Mark_' . l:id . ' text=' . l:str . ' texthl=' . l:SignatureSignTextHL
         execute 'sign place ' . l:id . ' line=' . l:lnum . ' name=sig_Mark_' . l:id . ' buffer=' . winbufnr(0)
       else
         execute 'sign unplace ' . l:id
@@ -286,7 +287,7 @@ function! s:ToggleSign( mark, mode, lnum ) "          {{{2
         let l:str = substitute(l:SignatureUcMarkStr, "\m", l:mark, "")
       endif
       let l:str = substitute(l:str, "\p", strpart(b:sig_marks[l:lnum], 1, 1), "")
-      execute 'sign define sig_Mark_' . l:id . ' text=' . l:str . ' texthl=Exception'
+      execute 'sign define sig_Mark_' . l:id . ' text=' . l:str . ' texthl=' . l:SignatureSignTextHL
       execute 'sign place ' . l:id . ' line=' . l:lnum . ' name=sig_Mark_' . l:id . ' buffer=' . winbufnr(0)
     endif
   endif

--- a/plugin/signature.vim
+++ b/plugin/signature.vim
@@ -218,6 +218,9 @@ endif
 if !exists('g:SignatureIncludeMarkers')
   let g:SignatureIncludeMarkers = ")!@#$%^&*("
 endif
+if !exists('g:SignatureSignTextHL')
+  let g:SignatureSignTextHL = "Exception"
+endif
 if !exists('g:SignatureWrapJumps')
   let g:SignatureWrapJumps = 1
 endif


### PR DESCRIPTION
Adding additional configuration setting, g:SignatureSignTextHL to
control highlight group used for displayed marks.
