### PR TITLE
let user keep or disable SignatureDefaultMappings

### DIFF
--- a/autoload/signature.vim
+++ b/autoload/signature.vim
@@ -481,7 +481,7 @@ function! signature#Init() "                          {{{2
   nnoremap <silent> <Plug>SIG_PurgeMarkers     :call signature#PurgeMarkers()<CR>
 
   " Enable/disable mappings
-  call signature#BufferMaps( 1 )
+  call signature#BufferMaps( g:SignatureEnableMappings )
 
 endfunction
 
@@ -693,7 +693,7 @@ function! signature#Toggle( mode ) "                  {{{2
   endif
 
   " Enable/disable mappings
-  call signature#BufferMaps( b:sig_status )
+  call signature#BufferMaps( g:SignatureEnableMappings && b:sig_status )
 
   if b:sig_status
     " Signature enabled ==> Refresh signs

--- a/doc/signature.txt
+++ b/doc/signature.txt
@@ -68,8 +68,12 @@ Signature provides just two commands
 
 Set up Signature the way you want using the following options
 
+'g:SignatureEnableMappings'                          *SignatureEnableMappings*
+  Boolean, Default : 1
+
+  Defines the following |SignatureDefaultMappings| mappings if set to 1.
+
                                                     *SignatureDefaultMappings*
-The following mappings are defined by default
   <Plug>SIG_PlaceNextMark    : Place next available mark ( m, )
   <Plug>SIG_PurgeMarks       : Remove all marks ( m<Space> )
   <Plug>SIG_PurgeMarkers     : Remove all markers ( m<BackSpace> )

--- a/plugin/signature.vim
+++ b/plugin/signature.vim
@@ -18,6 +18,9 @@ set cpo&vim
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 "" Global variables     {{{1
 "
+if !exists('g:SignatureEnableMappings')
+  let g:SignatureEnableMappings = 1
+endif
 if !exists('g:SignatureIncludeMarks')
   let g:SignatureIncludeMarks = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 endif


### PR DESCRIPTION
This commit adds the `g:SignatureEnableMappings` option (enabled by
default) which allows the user to disable SignatureDefaultMappings.
