### PR TITLE
enable mark mappings whenever entering buffers

### DIFF
--- a/plugin/signature.vim
+++ b/plugin/signature.vim
@@ -122,5 +122,9 @@ if ( g:SignatureMenu != 0 ) && has('gui_running')
 endif
 " }}}1
 
+augroup signature
+    au!
+    au BufEnter * call signature#BufferMaps(g:SignatureEnableDefaultMappings)
+augroup end
 
 call signature#Init()


### PR DESCRIPTION
Since `signature#BufferMaps()` shortcuts if mappings are already loaded for the current buffer, this is not as much overhead as I originally thought.

Closes #19.
