### PR TITLE
provide setting to avoid overriding '] and friends

### DIFF
--- a/autoload/signature.vim
+++ b/autoload/signature.vim
@@ -453,7 +453,8 @@ endfunction
 
 function! signature#BufferMaps( mode ) "                                              {{{2
   " Description: Set up mappings
-  " Arguments:   When mode = 1, enable  mappings.
+  " Arguments:   When mode = 1, enable all mappings.
+  "              When mode = 2, enable mappings except "ByAlpha" mappings.
 
   " To prevent maps from being called again when re-entering a buffer
   if !exists('b:sig_map_set') | let b:sig_map_set = 0 | endif
@@ -483,18 +484,22 @@ function! signature#BufferMaps( mode ) "                                        
       execute 'nmap <buffer> ' . g:SignatureLeader . '<BS>' . maparg( g:SignatureLeader . '<BS>', 'n' )
         \ . ' <Plug>SIG_PurgeMarkers'
     endif
-    if !hasmapto( '<Plug>SIG_NextLineByAlpha' )
-      execute "nmap <buffer> '] " . maparg( "']", 'n' ) . '<Plug>SIG_NextLineByAlpha'
+
+    if a:mode == 1
+      if !hasmapto( '<Plug>SIG_NextLineByAlpha' )
+        execute "nmap <buffer> '] " . maparg( "']", 'n' ) . '<Plug>SIG_NextLineByAlpha'
+      endif
+      if !hasmapto( '<Plug>SIG_PrevLineByAlpha' )
+        execute "nmap <buffer> '[ " . maparg( "'[", 'n' ) . '<Plug>SIG_PrevLineByAlpha'
+      endif
+      if !hasmapto( '<Plug>SIG_NextSpotByAlpha' )
+        execute 'nmap <buffer> `] ' . maparg( "`]", 'n' ) . '<Plug>SIG_NextSpotByAlpha'
+      endif
+      if !hasmapto( '<Plug>SIG_PrevSpotByAlpha' )
+        execute 'nmap <buffer> `[ ' . maparg( "`[", 'n' ) . '<Plug>SIG_PrevSpotByAlpha'
+      endif
     endif
-    if !hasmapto( '<Plug>SIG_PrevLineByAlpha' )
-      execute "nmap <buffer> '[ " . maparg( "'[", 'n' ) . '<Plug>SIG_PrevLineByAlpha'
-    endif
-    if !hasmapto( '<Plug>SIG_NextSpotByAlpha' )
-      execute 'nmap <buffer> `] ' . maparg( "`]", 'n' ) . '<Plug>SIG_NextSpotByAlpha'
-    endif
-    if !hasmapto( '<Plug>SIG_PrevSpotByAlpha' )
-      execute 'nmap <buffer> `[ ' . maparg( "`[", 'n' ) . '<Plug>SIG_PrevSpotByAlpha'
-    endif
+
     if !hasmapto( '<Plug>SIG_NextLineByPos' )
       execute "nmap <buffer> ]' " . maparg( "]'", 'n' ) . '<Plug>SIG_NextLineByPos'
     endif

--- a/doc/signature.txt
+++ b/doc/signature.txt
@@ -69,13 +69,17 @@ Signature provides just two commands
 Set up Signature the way you want using the following options
 
 'g:SignatureEnableDefaultMappings'            *SignatureEnableDefaultMappings*
-  Boolean, Default : 1
+  Integer, Default : 1
 
   If set to 1, defines the mappings as shown previously |signature-mappings|
   Note that if a mapping is already being used, Signature will preserve the
-  existing mapping and add its functionality
+  existing mapping and add its functionality.
 
-  To set up your own mappings, set this to 0 and use the following plugs
+  If set to 2, defines mappings similar to 1, except "ByAlpha" mappings; that 
+  is, the following mappings will NOT be set:   `]   `[   ']   '[
+
+  If set to 0, no default mappings are set. Use the following plugs to set up 
+  your own mappings:
 
   <Plug>SIG_PlaceNextMark    : Place next available mark
   <Plug>SIG_PurgeMarks       : Remove all marks


### PR DESCRIPTION
``[` and `'[` are useful for going back to the beginning of a large paste operation, or a `:r!` operation. Although I'm ok with opinionated, sane defaults, I also think plugins should strive to avoid overriding default mappings out-of-the-box.

So, I think the ideal solution might be to not map `'[` and friends by default. But this pull request doesn't take a stand on that. Rather, it just provides an additional option to disable these 4 mappings.

Although this is kind of ugly, it would be even uglier to require users to explicitly set `g:SignatureEnableDefaultMappings = 1` _and_ then have to manually specify the other mappings (which _are_ reasonable defaults).

I'd also suggest that cycling through marks in alphabetical order isn't such an important feature that it warrants overriding `'[`.
