### PR TITLE
Customize behavior when all marks are used and allow for linewise mark-purging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Once that's done, out of the box, the followings mappings are defined
 
 ````
   m[a-zA-Z]    : Toggle mark
-  m<Space>     : Delete all marks
   m,           : Place the next available mark
   m.           : If no mark on line, place the next available mark. Otherwise, remove (first) existing mark.
+  m-           : Delete all marks from the current line
+  m<Space>     : Delete all marks from the current buffer
   ]`           : Jump to next mark
   [`           : Jump to prev mark
   ]'           : Jump to start of next line containing a mark

--- a/autoload/signature.vim
+++ b/autoload/signature.vim
@@ -166,6 +166,10 @@ function! signature#Input()                       " {{{2
   if g:SignatureMap['ToggleMarkAtLine'] == "<Space>" && l:ascii == 32  | return s:ToggleMarkAtLine()      | endif
   if l:char == eval( '"\' . g:SignatureMap['ToggleMarkAtLine'] . '"' ) | return s:ToggleMarkAtLine()      | endif
 
+  if g:SignatureMap['PurgeMarksAtLine'] == "<CR>"    && l:ascii == 13  | return s:PurgeMarksAtLine()      | endif
+  if g:SignatureMap['PurgeMarksAtLine'] == "<Space>" && l:ascii == 32  | return s:PurgeMarksAtLine()      | endif
+  if l:char == eval( '"\' . g:SignatureMap['PurgeMarksAtLine'] . '"' ) | return s:PurgeMarksAtLine()      | endif
+
   if g:SignatureMap['PurgeMarks']    == "<CR>"    && l:ascii == 13     | return signature#PurgeMarks()   | endif
   if g:SignatureMap['PurgeMarks']    == "<Space>" && l:ascii == 32     | return signature#PurgeMarks()   | endif
   if l:char == eval( '"\' . g:SignatureMap['PurgeMarks'] . '"' )       | return signature#PurgeMarks()   | endif
@@ -205,6 +209,22 @@ function! s:ToggleMarkAtLine()                    " {{{2
   else
     " delete one mark
     call s:ToggleMark(l:marks_here[0])
+    return
+  endif
+endfunction
+" }}}2
+
+function! s:PurgeMarksAtLine()                    " {{{2
+  " Description: If no mark on current line, add one. If marks are on the
+  " current line, remove one.
+  let l:lnum = line('.')
+  " get list of marks wt this line (from s:MarksAt())
+  let l:marks_here = map(filter(s:LocalMarkList(), 'v:val[1]==' . l:lnum), 'v:val[0]')
+  if !empty(l:marks_here)
+    " delete one mark
+    for l:mark in l:marks_here
+      call s:ToggleMark(l:mark)
+    endfor
     return
   endif
 endfunction

--- a/doc/signature.txt
+++ b/doc/signature.txt
@@ -30,7 +30,8 @@ Out of the box, the followings mappings are defined by default
   m,           Place the next available mark
   m.           If no mark on line, place the next available mark. Otherwise,
                remove (first) existing mark.
-  m<Space>     Delete all marks
+  m-           Delete all marks from the current line
+  m<Space>     Delete all marks from the current buffer
   ]`           Jump to next mark
   [`           Jump to prev mark
   ]'           Jump to start of next line containing a mark
@@ -81,6 +82,7 @@ Set up Signature the way you want using the following options
       \ 'Leader'             :  "m",
       \ 'PlaceNextMark'      :  ",",
       \ 'ToggleMarkAtLine'   :  ".",
+      \ 'PurgeMarksAtLine'   :  "-",
       \ 'PurgeMarks'         :  "<Space>",
       \ 'PurgeMarkers'       :  "<BS>",
       \ 'GotoNextLineAlpha'  :  "']",

--- a/plugin/signature.vim
+++ b/plugin/signature.vim
@@ -89,6 +89,7 @@ if !exists ('g:SignatureMap'                     ) | let g:SignatureMap         
 if !has_key( g:SignatureMap, 'Leader'            ) | let g:SignatureMap['Leader'           ] = "m"       | endif
 if !has_key( g:SignatureMap, 'PlaceNextMark'     ) | let g:SignatureMap['PlaceNextMark'    ] = ","       | endif
 if !has_key( g:SignatureMap, 'ToggleMarkAtLine'  ) | let g:SignatureMap['ToggleMarkAtLine' ] = "."       | endif
+if !has_key( g:SignatureMap, 'PurgeMarksAtLine'  ) | let g:SignatureMap['PurgeMarksAtLine' ] = "-"       | endif
 if !has_key( g:SignatureMap, 'PurgeMarks'        ) | let g:SignatureMap['PurgeMarks'       ] = "<Space>" | endif
 if !has_key( g:SignatureMap, 'PurgeMarkers'      ) | let g:SignatureMap['PurgeMarkers'     ] = "<BS>"    | endif
 if !has_key( g:SignatureMap, 'GotoNextLineAlpha' ) | let g:SignatureMap['GotoNextLineAlpha'] = "']"      | endif


### PR DESCRIPTION
- Allow for mark recycling option: re-use mark when all marks are placed and new one requested 
- Control whether error or warning is given when all marks are exhausted
- Allow for all marks to be purged from current line only
