### PR TITLE
Make signature to appear on :h local-additions

### DIFF
--- a/doc/signature.txt
+++ b/doc/signature.txt
@@ -1,4 +1,4 @@
-signature.txt  A plugin to toggle, display and navigate marks
+*signature.txt*  A plugin to toggle, display and navigate marks
 
      _________.__                            __                              ~
     /   _____/|__|   ____    ____  _____   _/  |_  __ __ _______   ____      ~


### PR DESCRIPTION
First of all, thank you for sharing this great plugin!

This small change will create a link on `:help local-additions` to this plugin's documentation (as explained on `:h write-local-help`). I find this list useful as sometimes I have trouble remembering not only a plugin command, but also the plugin name itself :-)
