### PR TITLE
Fix key detection for ListLocalMarks

### DIFF
--- a/plugin/signature.vim
+++ b/plugin/signature.vim
@@ -311,7 +311,7 @@ function! signature#CreateMaps()                                                
   if !has_key( s:SignatureMap, 'GotoPrevMarker'    ) | let s:SignatureMap.GotoPrevMarker     =  "[-"                              | endif
   if !has_key( s:SignatureMap, 'GotoNextMarkerAny' ) | let s:SignatureMap.GotoNextMarkerAny  =  "]="                              | endif
   if !has_key( s:SignatureMap, 'GotoPrevMarkerAny' ) | let s:SignatureMap.GotoPrevMarkerAny  =  "[="                              | endif
-  if !has_key( s:SignatureMap, 'ListLocalMarks   ' ) | let s:SignatureMap.ListLocalMarks     =  "'?"                              | endif
+  if !has_key( s:SignatureMap, 'ListLocalMarks'    ) | let s:SignatureMap.ListLocalMarks     =  "'?"                              | endif
 
   if s:SignatureMap.Leader            != ""
     execute 'nnoremap <silent> <unique> ' . s:SignatureMap.Leader            . ' :call signature#Input()<CR>'


### PR DESCRIPTION
Trailing spaces within key detection made it very annoying to override default mapping for this specific key.
