### PR TITLE
Don't remap <Esc> in location list.

### DIFF
--- a/plugin/signature/mark.vim
+++ b/plugin/signature/mark.vim
@@ -401,7 +401,6 @@ function! signature#mark#List(scope)                                            
 
   if !exists("g:signature_set_location_list_convenience_maps") || g:signature_set_location_list_convenience_maps
     nnoremap <buffer> <silent> q        :q<CR>
-    noremap  <buffer> <silent> <ESC>    :q<CR>
     noremap  <buffer> <silent> <ENTER>  <CR>:lcl<CR>
   endif
 endfunction


### PR DESCRIPTION
I would suggest to not remap Esc (or do so optionally). Escape is a prefix to many keycodes, like arrow keys, and remapping it breaks them.