### PR TITLE
Support function references and strings in highlight expressions

### DIFF
--- a/doc/signature.txt
+++ b/doc/signature.txt
@@ -190,47 +190,77 @@ SignatureListMarkers [marker]
 
 
                                                      *'g:SignatureMarkTextHL'*
-  String, Default : 'Exception'
+  String, Default : "'Exception'"
 
-  The highlight group used for mark signs. This can be set to a function
-  reference can be assigned to this to allow dynamic highlighting of signs
-  NOTE: The quotes should be a part of the assignment.
-  Eg.   let g:SignatureMarkTextHL = "'Exception'"
+  The highlight group used for mark signs. This can be set either to a string
+  or to a |Funcref|.
 
+  If it holds a string, it must be an expression suitable for passing to
+  |eval()|. In the simple case, it can be the name of a highlight group. It can
+  also hold more complicated expressions, in which case the expression `a:lnum`
+  may be helpful. It holds the number of the line where the current mark is to
+  be highlighted.
+
+  If it holds a |Funcref|, then the function will be called with one argument,
+  the line number of the mark to be highlighted. The function should return
+  the name of a highlight group.
+
+  Example of simple string highlight group. Note the two sets of quotation
+  marks:
+>
+    let g:SignatureMarkTextHL = "'Exception'"
+<
+  Example of complex string expression:
+>
+    function Example(lineno)
+    endfunction
+    let g:SignatureMarkTextHL = "Example(a:lnum)"
+<
+  Example of |Funcref|:
+>
+    function Example(lineno)
+      return "Exception"
+    endfunction
+    let g:SignatureMarkTextHL = function("Example")
+<
 
                                               *'g:SignatureMarkTextHLDynamic'*
   Boolean, Default: 0
 
   Highlight signs of marks dynamically based upon state indicated by
-  vim-gitgutter or vim-signify
+  vim-gitgutter or vim-signify. Setting this to `1` prior to plugin
+  initialization overwrites |g:SignatureMarkTextHL|.
 
 
                                                      *'g:SignatureMarkLineHL'*
   String, Default : ''
 
-  The highlight group used for hightlighting lines having mark signs.
+  The highlight group used for hightlighting lines having mark signs. This can
+  be a string or a |Funcref|. See |g:SignatureMarkTextHL| for details.
 
 
                                                    *'g:SignatureMarkerTextHL'*
-  String, Default : 'WarningMsg'
+  String, Default : "'WarningMsg'"
 
-  The highlight group used for marker signs. This can be set to a function
-  reference can be assigned to this to allow dynamic highlighting of signs
-  NOTE: The quotes should be a part of the assignment.
-  Eg.   let g:SignatureMarkTextHL = "'WarningMsg'"
-
+  The highlight group used for marker signs. This can be a string or a
+  |Funcref|. See |g:SignatureMarkTextHL| for details.
+>
+    let g:SignatureMarkTextHL = "'WarningMsg'"
+<
 
                                             *'g:SignatureMarkerTextHLDynamic'*
   Boolean, Default: 0
 
   Highlight signs of markers dynamically based upon state indicated by
-  vim-gitgutter or vim-signify
+  vim-gitgutter or vim-signify. Setting this to `1` prior to plugin
+  initialization overwrites |g:SignatureMarkerTextHL|.
 
 
                                                    *'g:SignatureMarkerLineHL'*
   String, Default : ''
 
-  The highlight group used for hightlighting lines having marker signs.
+  The highlight group used for hightlighting lines having marker signs. This
+  can be a string or a |Funcref|. See |g:SignatureMarkTextHL| for details.
 
 
                                              *'g:SignatureDeleteConfirmation'*

--- a/plugin/signature/sign.vim
+++ b/plugin/signature/sign.vim
@@ -80,6 +80,17 @@ function! signature#sign#Remove(sign, lnum)                                     
 endfunction
 
 
+function! signature#sign#EvaluateHL(expression, lnum)                                                             " {{{1
+  if type(a:expression) == type("")
+    return eval(a:expression)
+  elseif type(a:expression) == type(function("tr"))
+    return a:expression(a:lnum)
+  else
+    return ""
+  endif
+endfunction
+
+
 function! signature#sign#RefreshLine(lnum)                                                                        " {{{1
   " Description: Decides what the sign string should be based on if there are any marks or markers (using b:sig_marks
   "              and b:sig_markers) on the current line and the value of b:SignaturePrioritizeMarks.
@@ -99,8 +110,8 @@ function! signature#sign#RefreshLine(lnum)                                      
 
     " If g:SignatureMarkTextHL points to a function, call it and use its output as the highlight group.
     " If it is a string, use it directly
-    let l:SignatureMarkLineHL = eval( g:SignatureMarkLineHL )
-    let l:SignatureMarkTextHL = eval( g:SignatureMarkTextHL )
+    let l:SignatureMarkLineHL = signature#sign#EvaluateHL(g:SignatureMarkLineHL, a:lnum)
+    let l:SignatureMarkTextHL = signature#sign#EvaluateHL(g:SignatureMarkTextHL, a:lnum)
     execute 'sign define Signature_' . l:str . ' text=' . l:str . ' texthl=' . l:SignatureMarkTextHL . ' linehl=' . l:SignatureMarkLineHL
 
   elseif has_key(b:sig_markers, a:lnum)
@@ -108,8 +119,8 @@ function! signature#sign#RefreshLine(lnum)                                      
 
     " If g:SignatureMarkerTextHL points to a function, call it and use its output as the highlight group.
     " If it is a string, use it directly
-    let l:SignatureMarkerLineHL = eval( g:SignatureMarkerLineHL )
-    let l:SignatureMarkerTextHL = eval( g:SignatureMarkerTextHL )
+    let l:SignatureMarkerLineHL = signature#sign#EvaluateHL(g:SignatureMarkerLineHL, a:lnum)
+    let l:SignatureMarkerTextHL = signature#sign#EvaluateHL(g:SignatureMarkerTextHL, a:lnum)
     execute 'sign define Signature_' . l:str . ' text=' . l:str . ' texthl=' . l:SignatureMarkerTextHL . ' linehl=' . l:SignatureMarkerLineHL
 
   else


### PR DESCRIPTION
Retains compatibility with existing configurations, but also supports
Vim function references. Fixes #91.
