### PR TITLE
refresh less often, avoid redraw in ToggleDummy

### DIFF
--- a/autoload/signature/sign.vim
+++ b/autoload/signature/sign.vim
@@ -171,6 +171,12 @@ function! signature#sign#Unplace(lnum)                                          
   silent! execute 'sign unplace ' . l:id
 endfunction
 
+function! s:HasPlacedSigns()                                                                                      " {{{1
+  redir => l:placeList
+  silent exe 'sign place buffer='.bufnr('%')
+  redir END
+  return (l:placeList !~ '---\n$')
+endfunction
 
 function! signature#sign#ToggleDummy(...)                                                                         " {{{1
   " Description: Places a dummy sign to prevent flickering of the gutter when the mark is moved or the line containing
@@ -188,7 +194,7 @@ function! signature#sign#ToggleDummy(...)                                       
   if (l:place)
     sign define Signature_Dummy
     execute 'sign place 666 line=1 name=Signature_Dummy buffer=' . bufnr('%')
-  elseif (l:remove)
+  elseif (l:remove && s:HasPlacedSigns())
     silent! execute 'sign unplace 666 buffer=' . bufnr('%')
   endif
 endfunction

--- a/plugin/signature.vim
+++ b/plugin/signature.vim
@@ -50,7 +50,7 @@ call signature#utils#Maps('create')
 if has('autocmd')
   augroup sig_autocmds
     autocmd!
-    autocmd BufEnter,CmdwinEnter * call signature#sign#Refresh()
+    autocmd BufWinEnter,CmdwinEnter * call signature#sign#Refresh()
     autocmd CursorHold * if g:SignaturePeriodicRefresh | call signature#sign#Refresh() | endif
     autocmd BufEnter,FileType * if (&filetype ==? 'nerdtree') | call signature#utils#Maps('remove') | endif
     autocmd BufLeave * if (&filetype ==? 'nerdtree') | call signature#utils#Maps('create') | endif


### PR DESCRIPTION
I noticed that a `sign unplace` on a nonexistent sign has the same effect of a `:redraw`, which is disrupting another plugin. Checking for the sign before trying to remove it seems a better approach.

The BufEnter also causes more flickering when executing batch action from others plugins (e.g.: `:RestartVim` from vim-session), and it is probably executed more than necessary: after loading the marks from viminfo, the user will be at the window when changing the marks.

 