### PR TITLE
Allow context with :SignatureListMarks

### DIFF
--- a/plugin/signature.vim
+++ b/plugin/signature.vim
@@ -59,5 +59,5 @@ endif
 
 command! -nargs=0 SignatureToggleSigns call signature#utils#Toggle()
 command! -nargs=0 SignatureRefresh     call signature#sign#Refresh('force')
-command! -nargs=0 SignatureListMarks   call signature#mark#List('buf_curr')
+command! -nargs=? SignatureListMarks   call signature#mark#List('buf_curr', <args>)
 command! -nargs=? SignatureListMarkers call signature#marker#List(<args>)

--- a/plugin/signature/utils.vim
+++ b/plugin/signature/utils.vim
@@ -57,7 +57,7 @@ function! signature#utils#Maps(mode)                                            
   call s:Map(a:mode, 'GotoPrevMarker'   , "[-"                            , 'marker#Goto("prev", "same", v:count)')
   call s:Map(a:mode, 'GotoNextMarkerAny', "]="                            , 'marker#Goto("next", "any",  v:count)')
   call s:Map(a:mode, 'GotoPrevMarkerAny', "[="                            , 'marker#Goto("prev", "any",  v:count)')
-  call s:Map(a:mode, 'ListLocalMarks'   , 'm/'                            , 'mark#List("buf_curr")'               )
+  call s:Map(a:mode, 'ListLocalMarks'   , 'm/'                            , 'mark#List("buf_curr", v:count)'      )
   call s:Map(a:mode, 'ListLocalMarkers' , 'm?'                            , 'marker#List()'                       )
 endfunction
 


### PR DESCRIPTION
I find it useful to use `m/` to create a summary of the main points of logs, but sometimes I miss the apability of including the surrounding lines.