### PR TITLE
The ID for sign cannot be negative, make sure it isnt

### DIFF
--- a/autoload/signature/sign.vim
+++ b/autoload/signature/sign.vim
@@ -104,7 +104,7 @@ function! s:RefreshLine(lnum)                                                   
   " Arguments:
   "   lnum : Line number for which the sign string is to be modified
 
-  let l:id  = a:lnum * 1000 + bufnr('%')
+  let l:id  = abs(a:lnum * 1000 + bufnr('%'))
   let l:str = ""
 
   " Place the sign
@@ -181,7 +181,7 @@ endfunction
 function! signature#sign#Unplace(lnum)                                                                            " {{{1
   " Description: Remove the sign from the specified line number
   " FIXME: Clean-up. Undefine the sign
-  let l:id = a:lnum * 1000 + bufnr('%')
+  let l:id = abs(a:lnum * 1000 + bufnr('%'))
   silent! execute 'sign unplace ' . l:id
 endfunction
 


### PR DESCRIPTION
For very large files, the current calculation for l:id will produce a negative number. This will cause an ugly error message from sign place.

Note that this shows up for me with 32bit vim on a file with approximately 3,000,000 lines. It makes sense that we're wrapping a 32bit int when we multiply by 1000.

This patch seems to fix it.