### PR TITLE
Bail out of signature#utils#Input() for netrw buffers

### DIFF
--- a/autoload/signature/utils.vim
+++ b/autoload/signature/utils.vim
@@ -67,6 +67,11 @@ endfunction
 function! signature#utils#Input()                                                                                 " {{{1
   " Description: Grab input char
 
+  if &ft ==# "netrw"
+    " Workaround for #104
+    return
+  endif
+
   " Obtain input from user ...
   let l:in = nr2char(getchar())
 


### PR DESCRIPTION
These buffers cannot have marks set in them, so we want to bail out in
this function. This avoids problems with vim-vinegar that were discussed
in #104.

```
  Error detected while processing function <SNR>90_NetrwBrowseChgDir[360]..signature#utils#Input:
  line    7:
  E121: Undefined variable: b:SignatureIncludeMarkers
  E15: Invalid expression: (b:SignatureIncludeMarkers =~# l:in)
  line   18:
  E121: Undefined variable: b:SignatureIncludeMarkers
  E15: Invalid expression: (  (b:SignatureIncludeMarkers =~# l:char) && (l:char != ' ') )
```

I am not sure if this is the best way or place to fix this, but it seems
to resolve the immediate issue for me.