### PR TITLE
Make #GetSignifyHLGroup() work with latest vim-signify

### DIFF
--- a/autoload/signature/sign.vim
+++ b/autoload/signature/sign.vim
@@ -294,7 +294,7 @@ function! signature#sign#GetSignifyHLGroup(lnum)                                
   if !exists('b:sy')
     return ""
   endif
-  call sy#sign#get_current_signs()
+  call sy#sign#get_current_signs(b:sy)
 
   if has_key(b:sy.internal, a:lnum)
     let l:line_state = b:sy.internal[a:lnum]['type']


### PR DESCRIPTION
When vim-signify switched to asynchronous execution a few months ago, we
couldn't rely on b:sy containing the correct data anymore. We now provide an
explicit argument to sy#sign#get_current_signs().

As far as I see, vim-signature works synchronously, so just providing b:sy to it
should make everything work like before.

Fixes https://github.com/kshenoy/vim-signature/issues/139