### PR TITLE
Fixed signature#mark#GetList() not correctly iterating b:SignatureIncludeMarks

### DIFF
--- a/autoload/signature/mark.vim
+++ b/autoload/signature/mark.vim
@@ -291,7 +291,7 @@ function! signature#mark#GetList(mode, scope, ...)                              
   let l:type     = (a:0 ? a:1 : "")
 
   " Respect order specified in g:SignatureIncludeMarks
-  for i in split(b:SignatureIncludeMarks)
+  for i in split(b:SignatureIncludeMarks, '\zs')
     if (i =~# "[A-Z]")
       let [ l:buf, l:line, l:col, l:off ] = getpos( "'" . i )
       let l:marks_list = add(l:marks_list, [i, l:line, l:buf])


### PR DESCRIPTION
After moving from NeoVim v0.2.2 to NeoVim v0.2.3-dev (21-02-2018), I noticed that toggling the next available mark at a line would briefly show 'ba' and consume all of the available marks.

It looks like the behaviour of split() with a single string argument changed somewhere along the line in both Vim and NeoVim so that it returns a list containing the entire string instead of a list where each element is a character in the string, which I assume was the old behaviour.

The fix should be clear from the commit.