### PR TITLE
Resolves issue #154 related to gitgutter compatibility

### DIFF
--- a/autoload/signature/sign.vim
+++ b/autoload/signature/sign.vim
@@ -284,7 +284,8 @@ endfunction
 function! signature#sign#GetGitGutterHLGroup(lnum)                                                                " {{{1
   " Description: This returns the highlight group used by vim-gitgutter depending on how the line was edited
 
-  let l:line_state = filter(copy(gitgutter#diff#process_hunks(gitgutter#hunk#hunks())), 'v:val[0] == a:lnum')
+  let l:current_bufnr = bufnr('%')
+  let l:line_state = filter(copy(gitgutter#diff#process_hunks(l:current_bufnr, gitgutter#hunk#hunks(l:current_bufnr))), 'v:val[0] == a:lnum')
 
   if len(l:line_state) == 0
     return ""


### PR DESCRIPTION
The maintainer of gitgutter has made the gitgutter#hunk#hunks() function
public again. All that needs to be done now is add the necessary buffer
information that needs to be added now which is what this PR fulfills.