### PR TITLE
Implement #159: Gutter always on

### DIFF
--- a/autoload/signature/sign.vim
+++ b/autoload/signature/sign.vim
@@ -201,8 +201,8 @@ function! signature#sign#ToggleDummy(...)                                       
   " Arguments: (optional) 0 : force remove
   "                       1 : force place
 
-  let l:place  = a:0 ?  a:1 : (len(b:sig_marks) + len(b:sig_markers) == 1) && !b:sig_DummyExists
-  let l:remove = a:0 ? !a:1 : (len(b:sig_marks) + len(b:sig_markers) == 0) &&  b:sig_DummyExists
+  let l:place  = a:0 ?  a:1 : (g:SignatureGutterAlwaysOn ? 1 : len(b:sig_marks) + len(b:sig_markers) == 1) && !b:sig_DummyExists
+  let l:remove = a:0 ? !a:1 : (g:SignatureGutterAlwaysOn ? 0 : len(b:sig_marks) + len(b:sig_markers) == 0) &&  b:sig_DummyExists
 
   if (l:place)
     sign define Signature_Dummy

--- a/doc/signature.txt
+++ b/doc/signature.txt
@@ -373,6 +373,13 @@ etc. These are not defined by default
   When set to 1, will always place markers instead of toggling them
 
 
+  *g:SignatureGutterAlwaysOn*
+  Boolean, Default: 0
+
+  When set to 1, will always display the gutter irrespective of whether there
+  are currently any marks to show or not.
+
+
 ==============================================================================
 4. Contributing                                        *SignatureContributing*
 

--- a/plugin/signature.vim
+++ b/plugin/signature.vim
@@ -39,6 +39,7 @@ call signature#utils#Set('g:SignatureErrorIfNoAvailableMarks', 1                
 call signature#utils#Set('g:SignatureForceRemoveGlobal',       0                                                     )
 call signature#utils#Set('g:SignatureForceMarkPlacement',      0                                                     )
 call signature#utils#Set('g:SignatureForceMarkerPlacement',    0                                                     )
+call signature#utils#Set('g:SignatureGutterAlwaysOn',          0                                                     )
 call signature#utils#Set('g:SignatureMap',                     {}                                                    )
 
 


### PR DESCRIPTION
This adds a new cusomisation variable called g:SignatureGutterAlwaysOn
which when enabled forces the gutter to always be shown. This is turned
off by default to maintain existing behaviour.