### PR TITLE
For split display mutiple markers

### DIFF
--- a/autoload/signature/marker.vim
+++ b/autoload/signature/marker.vim
@@ -157,6 +157,13 @@ function! signature#marker#List(...)                                            
         \             )
     endfor
 
+    " For split display mutiple markers
+    let l:list = add(l:list,
+      \              { 'text' : '------------------------------------------------------'
+      \              }
+      \             )
+
+
     " Add separator when showing context
     "if (a:context > 0)
     "  let l:list = add(l:list, l:list_sep)


### PR DESCRIPTION
if marker(!@#$%^&*()) as mutiple, when :SignatureListMarkers '', 3,  the preview is not obviously.
use '----------------------------' for split.