### PR TITLE
Update marks below text modifications, closing #140

### DIFF
--- a/doc/signature.txt
+++ b/doc/signature.txt
@@ -310,6 +310,13 @@ etc. These are not defined by default
     `set updatetime = 100`
 
 
+  *g:SignatureTextChangedRefresh*
+  Boolean, Default: 1
+
+  Enable the display to refresh upon changes. Generally a good thing to have.
+  This makes use of the TextChanged(I) autocmd events.
+
+
   *g:SignaturePrioritizeMarks*
   Boolean, Default: 1
 

--- a/plugin/signature.vim
+++ b/plugin/signature.vim
@@ -32,6 +32,7 @@ call signature#utils#Set('g:SignatureMarkOrder',               "\p\m"           
 call signature#utils#Set('g:SignatureDeleteConfirmation',      0                                                     )
 call signature#utils#Set('g:SignaturePurgeConfirmation',       0                                                     )
 call signature#utils#Set('g:SignaturePeriodicRefresh',         1                                                     )
+call signature#utils#Set('g:SignatureTextChangedRefresh',      1                                                     )
 call signature#utils#Set('g:SignatureEnabledAtStartup',        1                                                     )
 call signature#utils#Set('g:SignatureDeferPlacement',          1                                                     )
 call signature#utils#Set('g:SignatureRecycleMarks',            0                                                     )
@@ -59,6 +60,8 @@ if has('autocmd')
     autocmd BufEnter,CmdwinEnter * call signature#sign#Refresh()
 
     autocmd CursorHold * if (g:SignaturePeriodicRefresh) | call signature#sign#Refresh() | endif
+    autocmd TextChanged * if (g:SignatureTextChangedRefresh) | call signature#sign#TextChangedRefresh() | endif
+    autocmd TextChangedI * if (g:SignatureTextChangedRefresh) | call signature#sign#TextChangedRefresh() | endif
   augroup END
 endif
 


### PR DESCRIPTION
This PR removes and re-adds marks below the uppermost modified text line anytime `TextChanged` or `TextChangedI` fire for a much better experience.